### PR TITLE
Correct Pelican award number so it isn't PISM's

### DIFF
--- a/src/components/PartnerList/index.tsx
+++ b/src/components/PartnerList/index.tsx
@@ -77,7 +77,7 @@ const PartnerList = () => {
         name="Pelican"
         width={500}
         height={178}
-        awardId="2324718"
+        awardId="2331480"
         text={loremIpsum}
         containerStyles={{
           bgcolor: "secondary.main",


### PR DESCRIPTION
I noticed that Pelican's award number was the same as PISM's, and that following the link brought me to the NSF's page for PISM.

This PR fixes the award number for Pelican, as determined by https://www.nsf.gov/awardsearch/showAward?AWD_ID=2324718

Am I correct in assuming the `awardId` field is used automatically to generate the URL that clicking on the box redirects to? Or do I also need to correct the URL somewhere else?